### PR TITLE
Update openvm to v1.4.2-powdr-rc.3

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -30,14 +30,14 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 signature = { version = "2", optional = true }
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "v1.4.2-powdr-rc.2" }
+openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "v1.4.2-powdr-rc.3" }
 # Currently we have a circular dependency with the powdr repo:
 # - the k256 lib references the `hints-guest` crate in the powdr repo
 # - the powdr repo has a couple guest binaries that reference the k256 lib
 # - both reference openvm
 # When we upgrade openvm, the upgrade would have to be atomic in k256 and powdr, but that's not possible unless we have a monorepo.
 # Thus, this rev points to a commit in the powdr PR doing ovm the upgrade.
-powdr-openvm-hints-guest = { git = "https://github.com/powdr-labs/powdr.git", rev = "9098ba9c5" }
+powdr-openvm-hints-guest = { git = "https://github.com/powdr-labs/powdr.git", rev = "bc83204c1" }
 
 [dev-dependencies]
 blobby = "0.3"


### PR DESCRIPTION
## Summary
- Update openvm rev to `v1.4.2-powdr-rc.3`
- Update hints-guest rev to latest commit from https://github.com/powdr-labs/powdr/pull/3638

🤖 Generated with [Claude Code](https://claude.com/claude-code)