### PR TITLE
Update OpenVM to v2.0.0-beta.2

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -30,14 +30,14 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 signature = { version = "2", optional = true }
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "v1.4.2-powdr-rc.3" }
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "v2-powdr-beta.2" }
 # Currently we have a circular dependency with the powdr repo:
 # - the k256 lib references the `hints-guest` crate in the powdr repo
 # - the powdr repo has a couple guest binaries that reference the k256 lib
 # - both reference openvm
 # When we upgrade openvm, the upgrade would have to be atomic in k256 and powdr, but that's not possible unless we have a monorepo.
-# Thus, this rev points to a commit in the powdr PR doing ovm the upgrade.
-powdr-openvm-hints-guest = { git = "https://github.com/powdr-labs/powdr.git", rev = "bc83204c1" }
+# Thus, this rev points to a commit in the powdr PR doing the ovm upgrade.
+powdr-openvm-hints-guest = { git = "https://github.com/powdr-labs/powdr.git", rev = "59d625951" }
 
 [dev-dependencies]
 blobby = "0.3"


### PR DESCRIPTION
Update openvm dep to v2-powdr-beta.2 branch and powdr hints-guest to the OpenVM v2 integration PR commit.