### PR TITLE
Fix hints-guest crate name for v2

### DIFF
--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -37,7 +37,7 @@ openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "v2-powdr-
 # - both reference openvm
 # When we upgrade openvm, the upgrade would have to be atomic in k256 and powdr, but that's not possible unless we have a monorepo.
 # Thus, this rev points to a commit in the powdr PR doing the ovm upgrade.
-powdr-openvm-hints-guest = { git = "https://github.com/powdr-labs/powdr.git", rev = "59d625951" }
+powdr-openvm-riscv-hints-guest = { git = "https://github.com/powdr-labs/powdr.git", rev = "59d625951" }
 
 [dev-dependencies]
 blobby = "0.3"

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -174,7 +174,7 @@ impl FieldElement {
         #[cfg(target_os = "zkvm")]
         {
             let repr = self.0 .0;
-            let inv_repr = powdr_openvm_hints_guest::hint_k256_inverse_field_10x26(repr);
+            let inv_repr = powdr_openvm_riscv_hints_guest::hint_k256_inverse_field_10x26(repr);
             let inv = Self(FieldElementImpl(inv_repr));
             let normalizes_to_zero = self.normalizes_to_zero();
             if !bool::from(normalizes_to_zero) {
@@ -230,7 +230,7 @@ impl FieldElement {
         #[cfg(target_os = "zkvm")]
         {
             let repr = self.0 .0;
-            let (has_sqrt, sqrt) = powdr_openvm_hints_guest::hint_k256_sqrt_field_10x26(repr);
+            let (has_sqrt, sqrt) = powdr_openvm_riscv_hints_guest::hint_k256_sqrt_field_10x26(repr);
             let sqrt = Self(FieldElementImpl(sqrt));
             if has_sqrt {
                 if (sqrt * sqrt).normalize() != self.normalize() {
@@ -245,7 +245,7 @@ impl FieldElement {
                 if (sqrt * sqrt).normalize()
                     != (*self
                         * Self(FieldElementImpl(
-                            powdr_openvm_hints_guest::K256_NON_QUADRATIC_RESIDUE,
+                            powdr_openvm_riscv_hints_guest::K256_NON_QUADRATIC_RESIDUE,
                         )))
                     .normalize()
                 {


### PR DESCRIPTION
The crate was renamed from powdr-openvm-hints-guest to powdr-openvm-riscv-hints-guest.